### PR TITLE
[sync] 2020/8/23

### DIFF
--- a/examples/misc/lib/language_tour/classes/logger.dart
+++ b/examples/misc/lib/language_tour/classes/logger.dart
@@ -14,6 +14,10 @@ class Logger {
         name, () => Logger._internal(name));
   }
 
+  factory Logger.fromJson(Map<String, Object> json) {
+    return Logger(json['name'].toString());
+  }
+
   Logger._internal(this.name);
 
   void log(String msg) {
@@ -26,6 +30,9 @@ void main() {
   // #docregion logger
   var logger = Logger('UI');
   logger.log('Button clicked');
+
+  var logMap = {'name': 'UI'};
+  var loggerJson = Logger.fromJson(logMap);
   // #enddocregion logger
 
   var l1 = Logger('log1');
@@ -38,4 +45,6 @@ void main() {
   l1.log('${l1.name}: This is l1.');
   l2.log('${l2.name}: This is l1_2.');
   l3.log('${l3.name}: This is l2.');
+  logger.log('${logger.name}: This is logger.');
+  loggerJson.log('${loggerJson.name}: This is loggerJson.');
 }

--- a/examples/misc/test/language_tour/classes_test.dart
+++ b/examples/misc/test/language_tour/classes_test.dart
@@ -107,6 +107,8 @@ void main() {
           'log1: This is l1.',
           'log1: This is l1_2.',
           'log2: This is l2.',
+          'UI: This is logger.',
+          'UI: This is loggerJson.'
         ]));
   });
 

--- a/firebase.json
+++ b/firebase.json
@@ -126,6 +126,7 @@
       { "source": "/events/2016{,/**}", "destination": "https://events.dartlang.org/2016/summit", "type": 301 },
       { "source": "/events{,/**}", "destination": "https://events.dartlang.org", "type": 301 },
       { "source": "/flutter", "destination": "https://flutter.io", "type": 301 },
+      { "source": "/go/null-safety-migration", "destination": "https://github.com/dart-lang/sdk/tree/master/pkg/nnbd_migration#providing-feedback", "type": 301 },
       { "source": "/googleapis", "destination": "https://github.com/dart-lang/googleapis", "type": 301 },
       { "source": "/guides/language/common-prob", "destination": "/guides/language/sound-problems", "type": 301 },
       { "source": "/guides/language/library-tour", "destination": "/guides/libraries/library-tour", "type": 301 },

--- a/src/_guides/language/effective-dart/usage.md
+++ b/src/_guides/language/effective-dart/usage.md
@@ -1411,7 +1411,6 @@ forget to initialize it if the class has multiple constructors.
 
 <!-- Q: As of 2.9, this code no longer works.
   Should we change it or the recommendation? -->
-  
 {:.bad}
 <!-- code-excerpt "misc/lib/effective_dart/usage_bad.dart (field-init-at-decl)" -->
 {% prettify dart tag=pre+code %}

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -3977,17 +3977,25 @@ For details, see the section on
 
 Use the `factory` keyword when implementing a constructor that doesn’t
 always create a new instance of its class. For example, a factory
-constructor might return an instance from a cache, or it might return an
-instance of a subtype.
+constructor might return an instance from a cache, or it might
+return an instance of a subtype.
+Another use case for factory constructors is
+initializing a final variable using
+logic that can't be handled in the initializer list. 
 
 使用 `factory` 关键字标识类的构造函数将会令该构造函数变为工厂构造函数，
 这将意味着使用该构造函数构造类的实例时并非总是会返回新的实例对象。
 例如，工厂构造函数可能会从缓存中返回一个实例，或者返回一个子类型的实例。
 
-The following example demonstrates a factory constructor returning
-objects from a cache:
+In the following example,
+the `Logger` factory constructor returns objects from a cache,
+and the `Logger.fromJson` factory constructor
+initializes a final variable from a JSON object.
 
-以下示例演示了从缓存中返回对象的工厂构造函数：
+在如下的示例中，
+`Logger` 的工厂构造函数从缓存中返回对象，
+和 `Logger.fromJson` 工厂构造函数从 JSON 对象中
+初始化一个最终变量。
 
 <?code-excerpt "misc/lib/language_tour/classes/logger.dart"?>
 ```dart
@@ -4002,6 +4010,10 @@ class Logger {
   factory Logger(String name) {
     return _cache.putIfAbsent(
         name, () => Logger._internal(name));
+  }
+
+  factory Logger.fromJson(Map<String, Object> json) {
+    return Logger(json['name'].toString());
   }
 
   Logger._internal(this.name);
@@ -4028,6 +4040,9 @@ Invoke a factory constructor just like you would any other constructor:
 ```dart
 var logger = Logger('UI');
 logger.log('Button clicked');
+
+var logMap = {'name': 'UI'};
+var loggerJson = Logger.fromJson(logMap);
 ```
 
 
@@ -4385,6 +4400,8 @@ For more information on overriding, in general, see
 
 #### noSuchMethod()
 
+#### noSuchMethod 方法
+
 To detect or react whenever code attempts to use a non-existent method or
 instance variable, you can override `noSuchMethod()`:
 
@@ -4424,7 +4441,9 @@ that's different from the one in class `Object`.
 For more information, see the informal
 [noSuchMethod forwarding specification.](https://github.com/dart-lang/sdk/blob/master/docs/language/informal/nosuchmethod-forwarding.md)
 
-你可以查阅 [noSuchMethod 转发规范](https://github.com/dart-lang/sdk/blob/master/docs/language/informal/nosuchmethod-forwarding.md)获取更多相关信息。
+你可以查阅
+[noSuchMethod 转发规范](https://github.com/dart-lang/sdk/blob/master/docs/language/informal/nosuchmethod-forwarding.md)
+获取更多相关信息。
 
 
 ### Extension methods
@@ -5147,7 +5166,8 @@ allows a web app to load a library on demand,
 if and when the library is needed.
 Here are some cases when you might use deferred loading:
 
-_延迟加载_（也常称为 _懒加载_）允许应用在需要时再去加载代码库，下面是可能使用到延迟加载的场景：
+_延迟加载_（也常称为 _懒加载_）允许应用在需要时再去加载代码库，
+下面是可能使用到延迟加载的场景：
 
 * To reduce a web app's initial startup time.
 
@@ -5852,7 +5872,11 @@ constructor, factory, function, field, parameter, or variable
 declaration and before an import or export directive. You can
 retrieve metadata at runtime using reflection.
 
-元数据可以在 library、class、typedef、type parameter、constructor、factory、function、field、parameter 或者 variable 声明之前使用，也可以在 import 或 export 之前使用。可使用反射在运行时获取元数据信息。
+元数据可以在 library、class、typedef、type parameter、
+constructor、factory、function、field、parameter
+或者 variable 声明之前使用，
+也可以在 import 或 export 之前使用。
+可使用反射在运行时获取元数据信息。
 
 
 ## Comments
@@ -5891,7 +5915,9 @@ between `/*` and `*/` is ignored by the Dart compiler (unless the
 comment is a documentation comment; see the next section). Multi-line
 comments can nest.
 
-多行注释以  `/*`  开始， 以 `*/` 结尾。所有在 `/*` 和 `*/` 之间的内容被编译器忽略（不会忽略文档注释）。多行注释可以嵌套。
+多行注释以  `/*`  开始， 以 `*/` 结尾。所有在 `/*` 和 `*/`
+之间的内容被编译器忽略（不会忽略文档注释），
+多行注释可以嵌套。
 
 <?code-excerpt "misc/lib/language_tour/comments.dart (multi-line-comments)"?>
 ```dart
@@ -5916,7 +5942,9 @@ Documentation comments are multi-line or single-line comments that begin
 with `///` or `/**`. Using `///` on consecutive lines has the same
 effect as a multi-line doc comment.
 
-文档注释可以是多行注释，也可以是单行注释，文档注释以 `///` 或者 `/**` 开始。在连续行上使用 `///` 与多行文档注释具有相同的效果。
+文档注释可以是多行注释，也可以是单行注释，
+文档注释以 `///` 或者 `/**` 开始。
+在连续行上使用 `///` 与多行文档注释具有相同的效果。
 
 Inside a documentation comment, the Dart compiler ignores all text
 unless it is enclosed in brackets. Using brackets, you can refer to
@@ -5924,7 +5952,9 @@ classes, methods, fields, top-level variables, functions, and
 parameters. The names in brackets are resolved in the lexical scope of
 the documented program element.
 
-在文档注释中，除非用中括号括起来，否则 Dart 编译器会忽略所有文本。使用中括号可以引用类、 方法、 字段、 顶级变量、 函数、 和参数。括号中的符号会在已记录的程序元素的词法域中进行解析。
+在文档注释中，除非用中括号括起来，否则 Dart 编译器会忽略所有文本。
+使用中括号可以引用类、方法、字段、顶级变量、函数和参数。
+括号中的符号会在已记录的程序元素的词法域中进行解析。
 
 Here is an example of documentation comments with references to other
 classes and arguments:
@@ -5967,8 +5997,13 @@ documentation.]({{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}) For advice
 your comments, see
 [Guidelines for Dart Doc Comments.](/guides/language/effective-dart/documentation)
 
-解析 Dart 代码并生成 HTML 文档，可以使用 SDK 中的[文档生成工具。](https://github.com/dart-lang/dartdoc#dartdoc)关于生成文档的实例，请参考 [Dart API
-documentation.]({{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}})关于文档结构的建议，请参考[Guidelines for Dart Doc Comments.](/guides/language/effective-dart/documentation)
+解析 Dart 代码并生成 HTML 文档，可以使用 SDK 中的 
+[文档生成工具](https://github.com/dart-lang/dartdoc#dartdoc) 关于生成文档的实例，
+请参考
+[Dart API documentation]({{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}) 
+查看关于文档结构的建议，
+请参考文档：
+[Guidelines for Dart Doc Comments.](/guides/language/effective-dart/documentation)。
 
 
 ## Summary
@@ -5980,12 +6015,16 @@ More features are being implemented, but we expect that they won’t break
 existing code. For more information, see the [Dart language specification][] and
 [Effective Dart](/guides/language/effective-dart).
 
-本页概述了 Dart 语言中常用的功能。还有更多特性有待实现，但我们希望它们不会破坏现有代码。有关更多信息，请参考 [Dart 语言规范][]和[高效 Dart 语言指南](/guides/language/effective-dart)。
+本页概述了 Dart 语言中常用的功能。还有更多特性有待实现，
+但我们希望它们不会破坏现有代码。有关更多信息，
+请参考 [Dart 语言规范][Dart language specification] 和
+[高效 Dart 语言指南](/guides/language/effective-dart)。
 
 To learn more about Dart's core libraries, see
 [A Tour of the Dart Libraries](/guides/libraries/library-tour).
 
-要了解更多关于 Dart 核心库的内容，请参考 [Dart 核心库概览](/guides/libraries/library-tour)。
+要了解更多关于 Dart 核心库的内容，
+请参考 [Dart 核心库概览](/guides/libraries/library-tour)。
 
 [AssertionError]: {{site.dart_api}}/{{site.data.pkg-vers.SDK.channel}}/dart-core/AssertionError-class.html
 [`Characters`]: {{site.pub-api}}/characters/latest/characters/Characters-class.html

--- a/src/_guides/language/type-system.md
+++ b/src/_guides/language/type-system.md
@@ -328,7 +328,8 @@ class HoneyBadger extends Animal {
 The following code tightens the parameter on the `chase()` method
 from Animal to Mouse, a subclass of Animal.
 
-Mouse 是 Animal 的子类，下面的代码将 `chase()` 方法中参数的范围从 Animal 缩小到 Mouse 。
+Mouse 是 Animal 的子类，下面的代码将 `chase()`
+方法中参数的范围从 Animal 缩小到 Mouse 。
 
 {:.fails-sa}
 {% prettify dart tag=pre+code %}
@@ -342,9 +343,9 @@ class Cat extends Animal {
 This code is not type safe because it would then be possible to define
 a cat and send it after an alligator:
 
-下面的代码不是类型安全的，因为 a 可以是一个 cat 对象，却可以给它传入一个 alligator 对象。
+下面的代码不是类型安全的，因为 a 可以是一个 cat 对象，
+却可以给它传入一个 alligator 对象。
 
-<?code-excerpt "strong/lib/animal_bad.dart (chase-Alligator)" replace="/Alligator/[!$&!]/g"?>
 {% prettify dart tag=pre+code %}
 Animal a = Cat();
 a.chase([!Alligator!]()); // Not type safe or feline safe
@@ -564,7 +565,8 @@ with a declared type) with something that has another type
 has one type with something that has a subtype or a supertype?
 
 当重写方法时，可以使用一个新类型（在新方法中）替换旧类型（在旧方法中）。
-类似地，当参数传递给函数时，可以使用另一种类型（实际参数）的对象替换现有类型（具有声明类型的参数）要求的对象。
+类似地，当参数传递给函数时，可以使用另一种类型（实际参数）
+的对象替换现有类型（具有声明类型的参数）要求的对象。
 什么时候可以用具有子类型或父类型的对象替换具有一种类型的对象那？
 
 When substituting types, it helps to think in terms of _consumers_

--- a/src/_includes/get-sdk.md
+++ b/src/_includes/get-sdk.md
@@ -3,7 +3,7 @@ you need an SDK.
 You can either download the Dart SDK directly
 (as described below)
 or [download the Flutter SDK,][]
-which (as of Flutter 1.21) includes the Dart SDK.
+which (as of Flutter 1.21) includes the full Dart SDK.
 
 [download the Flutter SDK,]: {{site.flutter}}/docs/get-started/install
 

--- a/src/_tutorials/server/get-started.md
+++ b/src/_tutorials/server/get-started.md
@@ -162,7 +162,8 @@ These commands create a small Dart app that has the following:
   information about which [packages](/guides/packages) the app depends on
   and which versions of those packages are required.
 
-  一个 pubspec 文件，`pubspec.yaml`，包含应用的元数据，包括应用依赖的 [包](/guides/packages) 信息以及所需的版本等。
+  一个 pubspec 文件，`pubspec.yaml`，包含应用的元数据，包括应用依赖的
+  [package](/guides/packages) 信息以及所需的版本等。
 
 ## 5. Get the app's dependencies
 

--- a/src/codelabs/dart-cheatsheet.md
+++ b/src/codelabs/dart-cheatsheet.md
@@ -529,7 +529,7 @@ class MyClass {
   // Returns the product of the above values:
   int get product => _value1 * _value2 * _value3;
   
-  // Adds one to _value1:
+  // Adds 1 to _value1:
   void incrementValue1() => _value1++; 
   
   // Returns a string containing each item in the

--- a/src/get-dart.md
+++ b/src/get-dart.md
@@ -17,13 +17,13 @@ For details, see the [Dart SDK overview](/tools/sdk).
 Dart SDK 包含开发 Web、命令行和服务端应用所需要的库和命令行工具。
 更多详细内容，请参考 [Dart SDK 概览](/tools/sdk) 文档。
 
-**As of Flutter 1.21, the [Flutter SDK][flutter] includes the Dart SDK.**
+**As of Flutter 1.21, the [Flutter SDK][flutter] includes the full Dart SDK.**
 So if you have Flutter installed,
 you might not need to explicitly download the Dart SDK.
 Consider downloading the Dart SDK if
 any of the following are true:
 
-**从 Flutter 1.21 版本开始，[Flutter SDK][flutter] 会同时包含 Dart SDK**
+**从 Flutter 1.21 版本开始，[Flutter SDK][flutter] 会同时包含完整的 Dart SDK**
 因此如果你已经安装了 Flutter，可能就无需再特别下载 Dart SDK 了。
 如果你有下述的需求，请考虑下载 Dart SDK：
 
@@ -44,6 +44,7 @@ any of the following are true:
   设置 CI 时，需要 Dart 并不需要 Flutter。
 
 <aside class="alert alert-info" markdown="1">
+
   **Note:** This site's documentation and examples use
   {% if site.data.pkg-vers.SDK.channel == 'dev' %} the **dev channel** {% endif -%}
   version [{{site.data.pkg-vers.SDK.vers}}][site SDK version]{:.no-automatic-external}

--- a/src/tools/index.md
+++ b/src/tools/index.md
@@ -31,7 +31,8 @@ If you aren't sure which tools you need, **get the Flutter SDK.**
 
   As of Flutter 1.21, the Flutter SDK includes the Dart SDK.
   
-  从 Flutter 1.21 版本开始，[Flutter SDK][flutter] 同时包含了 Dart SDK。
+  从 Flutter 1.21 版本开始，
+  [Flutter SDK][flutter] 同时包含了完整的 Dart SDK。
   
 {{site.alert.end}}
 
@@ -63,7 +64,10 @@ and to experiment with Dart language features.
 It supports Dart's core libraries,
 except for VM libraries such as dart:io.
 
-<img src="{% asset dartpad-hello.png @path %}" alt="DartPad Hello World" width="200px" align="right" /> [DartPad](/tools/dartpad) 是一个用于学习 Dart 语法以及体验 Dart  语言功能的在线工具。它支持 Dart 的核心库，但不支持类似 dart:io 这样的 VM 库。
+<img src="{% asset dartpad-hello.png @path %}" alt="DartPad Hello World" width="200px" align="right" /> 
+[DartPad](/tools/dartpad) 是一个用于学习 Dart 语法以及
+体验 Dart 语言功能的在线工具。
+它支持 Dart 的核心库，但不支持类似 dart:io 这样的 VM 库。
 
 ### IDEs and editors
 

--- a/src/tools/jetbrains-plugin.md
+++ b/src/tools/jetbrains-plugin.md
@@ -12,21 +12,29 @@ with support for many other languages and frameworks.
 Android Studio is an IDE based on IntelliJ IDEA
 that's used for Android and Flutter development.
 
-Dart 插件为类似 IntelliJ IDEA 和 Android Studio 这样 JetBrains 的 IDE 提供了 Dart 支持。IntelliJ IDEA 是一款优秀的 Java IDE，除此之外它还支持许多其它的语言和框架。Android Studio 是一款基于 IntelliJ IDEA 的 IDE，其常用作开发 Android 和 Flutter。
+Dart 插件为类似 IntelliJ IDEA 和 Android Studio
+这样 JetBrains 的 IDE 提供了 Dart 支持。
+IntelliJ IDEA 是一款优秀的 Java IDE，
+除此之外它还支持许多其它的语言和框架。
+Android Studio 是一款基于 IntelliJ IDEA 的 IDE，
+其常用作开发 Android 和 Flutter。
 
 Whichever JetBrains IDE you choose for Dart development,
 this page has resources to help you get started quickly
 and find more information when you need it.
 
-不管你选择哪一款 JetBrains 的 IDE 用于 Dart 开发，本文所包含的资源都可以帮助你快速入门并在你需要时给你提供更多的信息。
+不管你选择哪一款 JetBrains 的 IDE 用于 Dart 开发，
+本文所包含的资源都可以帮助你快速入门并在你需要时给你提供更多的信息。
 
 <aside class="alert alert-info" markdown="1">
+
   **Note:**
   [WebStorm,](https://www.jetbrains.com/webstorm/)
   a JetBrains IDE for client-side development,
   comes with the Dart plugin pre-installed.
 
-  **注意：** JetBrains 专门针对客户端开发的另一款 IDE [WebStorm](https://www.jetbrains.com/webstorm/) 则已经预装了 Dart 插件。
+  **注意：** JetBrains 专门针对客户端开发的另一款 IDE
+  [WebStorm](https://www.jetbrains.com/webstorm/) 则已经预装了 Dart 插件。
 </aside>
 
 ## Getting started
@@ -51,7 +59,9 @@ Install a JetBrains IDE if you don't already have one.
   to try out the latest Dart language features,
   [install IntelliJ IDEA EAP.](https://confluence.jetbrains.com/display/IDEADEV/EAP)
 
-  <a href="https://www.jetbrains.com/idea/download/" target="_blank" rel="noopener">下载 IntelliJ IDEA</a> 或，尝试试用最新的 Dart 语言特性，[请安装 IntelliJ IDEA EAP](https://confluence.jetbrains.com/display/IDEADEV/EAP)。
+  <a href="https://www.jetbrains.com/idea/download/" target="_blank" rel="noopener">下载 IntelliJ IDEA</a>
+  或尝试试用最新的 Dart 语言特性，
+  [请安装 IntelliJ IDEA EAP](https://confluence.jetbrains.com/display/IDEADEV/EAP)。
 
 * Or <a href="https://www.jetbrains.com/products.html"
   target="_blank" rel="noopener">find another JetBrains product.</a>
@@ -59,6 +69,7 @@ Install a JetBrains IDE if you don't already have one.
   或者 <a href="https://www.jetbrains.com/products.html" target="_blank" rel="noopener">查找其它的 JetBrains 产品。</a>
 
 <aside class="alert alert-info" markdown="1">
+
   **Note:**
   The Community Edition of IntelliJ IDEA has limited functionality.
   For example, it doesn't directly support debugging web apps.
@@ -78,11 +89,18 @@ install it.
 You can get it either by itself or by downloading the Flutter SDK,
 which (as of Flutter 1.21) includes the Dart SDK.
 
+如果你还没有安装 Dart SDK，安装一下。
+你可以选择下载 Dart SDK 或者下载安装 Flutter SDK，
+在 Flutter 1.21 和之后的版本，Flutter SDK 已经包含了完整的 Dart SDK 。
+
 Choose one:
 
-如果你还没有 Dart SDK，请先安装。
+选一个吧：
 
 * [Download the Dart SDK](/get-dart)
+ 
+  [下载 Dart SDK](/get-dart)
+
 * [Download the Flutter SDK]({{site.flutter}}/docs/get-started/install)
 
   [下载 Dart SDK](/get-dart)
@@ -106,7 +124,11 @@ Here's one way to configure Dart support:
     and then search or scroll down until you find <b>Dart</b>.
     Once you've installed the Dart plugin, restart the IDE.
 
-    启动 IDE 并安装 <b>Dart</b> 插件。你可以从欢迎界面窗口的 <b>Configure > Plugins</b> 菜单进入到插件设置界面，然后点击 <b>Install JetBrains plugin</b> 并搜索或拖动滚动条直到你找到 <b>Dart</b>。安装好 Dart 插件后记得重启 IDE。
+    启动 IDE 并安装 <b>Dart</b> 插件。你可以从欢迎界面窗口的 
+    <b>Configure > Plugins</b> 菜单进入到插件设置界面，
+    然后点击 <b>Install JetBrains plugin</b> 并搜索或拖动滚动条
+    直到你找到 <b>Dart</b>。
+    安装好 Dart 插件后记得重启 IDE。
   </p>
 </li>
 
@@ -152,7 +174,9 @@ Here's one way to configure Dart support:
   The IDE ensures that the path is valid.
 
   <b>注意：</b>
-  <b>Dart SDK</b> 路径为包含了 `bin` 和 `lib` 目录的路径；`bin` 目录中包含了类似 `dart` 和 `dartfmt` 的工具。需要确保 IDE 路径有效。
+  <b>Dart SDK</b> 路径为包含了 `bin` 和 `lib` 目录的路径；
+  `bin` 目录中包含了类似 `dart` 和 `dartfmt` 的工具。
+  需要确保 IDE 路径有效。
 </aside>
 </li>
 </ol>
@@ -160,7 +184,8 @@ Here's one way to configure Dart support:
 An alternative to Step 2 is to open an existing Dart project,
 and then open its `pubspec.yaml` file or any of its Dart files.
 
-如果你已经创建过 Dart 项目，则可以在第二步的时候选择打开该项目，然后选择打开 `pubspec.yaml` 或其它 Dart 文件。
+如果你已经创建过 Dart 项目，则可以在第二步的时候选择打开该项目，
+然后选择打开 `pubspec.yaml` 或其它 Dart 文件。
 
 {% comment %}
 

--- a/src/tools/sdk/index.md
+++ b/src/tools/sdk/index.md
@@ -15,7 +15,7 @@ To learn about other tools you can use for Dart development, see
 the [Dart tools](/tools) page.
 
 {{site.alert.version-note}}
-  As of Flutter 1.21, the Flutter SDK includes the Dart SDK.
+  As of Flutter 1.21, the Flutter SDK includes the full Dart SDK.
   This site's documentation and examples use
   {% if site.data.pkg-vers.SDK.channel == 'dev' %} the **dev channel** {% endif -%}
   version [{{site.data.pkg-vers.SDK.vers}}][site SDK version]{:.no-automatic-external}


### PR DESCRIPTION
ref #123 

主要是强调了自 Flutter 1.21 和之后的版本，Flutter SDK 会包含完整的 Dart SDK 的说明。