### PR TITLE
Update language-tour.md

### DIFF
--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -2606,15 +2606,6 @@ if (employee is Person) {
 }
 ```
 
-You can make the code shorter using the `as` operator:
-
-你可以使用 `as` 运算符进行缩写：
-
-<?code-excerpt "misc/lib/language_tour/classes/employee.dart (emp as Person)"?>
-```dart
-(emp as Person).firstName = 'Bob';
-```
-
 {{site.alert.note}}
 
   The code isn’t equivalent. If `employee` is null or not a `Person`, the


### PR DESCRIPTION
官网没有这句说明，这句会引发下面一段的歧义
```
上述两种方式是有区别的：如果 employee 为 null 或者不为 Person 类型，则第一种方式将会抛出异常，而第二种不会。
官网地址
```
https://dart.dev/guides/language/language-tour#type-test-operators