### PR TITLE
Check `window.Cookie` before use in `main.js`

### DIFF
--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -122,7 +122,7 @@ function initCookieNotice() {
   const cookieConsentValue = 'true'
   const activeClass = 'show';
 
-  if (Cookies.get(cookieKey) === cookieConsentValue) {
+  if (window.Cookie === undefined || Cookies.get(cookieKey) === cookieConsentValue) {
     return;
   }
 

--- a/src/assets/js/main.js
+++ b/src/assets/js/main.js
@@ -139,7 +139,7 @@ $(function() {
   fixNav(); // Adjust heights for navigation elements
   prettyPrint(); // Initiate Syntax Highlighting
   setupOsTabs();
-  initCookieNotice();
+  // initCookieNotice();
 
   // Sidenav
   $('#sidenav i').on('click', function (e) {


### PR DESCRIPTION
### 解决的 Issues

Fix #382.

### 更新内容描述

由于我们全站移除了 Cookie，导致 `Cookie` 并未在 `window` 中定义，在调用初始化时会空调用。
PR 有如下修改：
- 调用前检查 `Cookie` 存在；
- 移除了文件内的调用。（由于其未闭包，暂时未确认其他文件是否有调用。）