### PR TITLE
link fixes

### DIFF
--- a/src/_guides/libraries/useful-libraries.md
+++ b/src/_guides/libraries/useful-libraries.md
@@ -88,7 +88,7 @@ See [Using packages]({{site.flutter-docs}}/development/packages-and-plugins/usin
 on the Flutter site.
 Or use the pub.dev site to [search for Flutter packages.]({{site.pub}}/flutter)
 
-在 Flutter 网站，查看 [package 的使用]({{site.flutter_docs}}/development/packages-and-plugins/using-packages)。
+在 Flutter 网站，查看 [package 的使用]({{site.flutter-docs}}/development/packages-and-plugins/using-packages)。
 或者使用 Pub 网站 [查找 Flutter package]({{site.pub}}/flutter)。
 
 ### Web packages

--- a/src/tools/jetbrains-plugin.md
+++ b/src/tools/jetbrains-plugin.md
@@ -103,7 +103,7 @@ Choose one:
 
 * [Download the Flutter SDK]({{site.flutter-docs}}/get-started/install)
 
-  [下载 Flutter SDK]({{site.flutter_docs}}/get-started/install)
+  [下载 Flutter SDK]({{site.flutter-docs}}/get-started/install)
 
 
 ### Configuring Dart support


### PR DESCRIPTION
[CI](https://github.com/cfug/dart.cn/actions/runs/3358325788/jobs/5565191778#step:8:65) 中遇到了两处链接错误问题导致无法部署，原因是 `site.flutter-docs` 的引用出错了，这个 PR 已经修复了这个问题。