### PR TITLE
link anchor missing issues fixed

### DIFF
--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -1207,6 +1207,7 @@ You can add a comma after the last item in a Dart collection literal.
 This _trailing comma_ doesn't affect the collection,
 but it can help prevent copy-paste errors.
 
+<a name="trailing-comma"></a>
 你可以在 Dart 的集合类型的最后一个项目后添加逗号。
 这个尾随逗号并不会影响集合，但它能有效避免「复制粘贴」的错误。
 
@@ -1255,6 +1256,7 @@ Dart supports the **spread operator** (`...`) and the
 **null-aware spread operator** (`...?`),
 which provide a concise way to insert multiple values into a collection.
 
+<a id="spread-operator"> </a>
 Dart 在 2.3 引入了 **扩展操作符**（`...`）和 **空感知扩展操作符**（`...?`），
 它们提供了一种将多个元素插入集合的简洁方法。
 
@@ -1293,6 +1295,7 @@ Dart also offers **collection if** and **collection for**,
 which you can use to build collections using conditionals (`if`)
 and repetition (`for`).
 
+<a id="collection-operators"> </a>
 Dart 还同时引入了 **集合中的 if** 和 **集合中的 for** 操作，
 在构建集合时，可以使用条件判断 (`if`) 和循环 (`for`)。
 
@@ -1778,7 +1781,7 @@ Although Effective Dart recommends
 the function still works if you omit the types:
 
 虽然高效 Dart 指南建议在
-[公开的 API 上定义返回类型](/guides/language/effective-dart/design#prefer-type-annotating-public-fields-and-top-level-variables-if-the-type-isnt-obvious)，
+[公开的 API 上定义返回类型](/guides/language/effective-dart/design#do-type-annotate-fields-and-top-level-variables-if-the-type-isnt-obvious)，
 不过即便不定义，该函数也依然有效：
 
 <?code-excerpt "misc/lib/language_tour/functions.dart (function-omitting-types)"?>
@@ -2807,7 +2810,7 @@ assert((-value >>> 4) > 0); // Unsigned shift right
 Dart has two operators that let you concisely evaluate expressions
 that might otherwise require [if-else](#if-and-else) statements:
 
-Dart 有两个特殊的运算符可以用来替代 [if-else](#if-和-else) 语句：
+Dart 有两个特殊的运算符可以用来替代 [if-else](#if-and-else) 语句：
 
 <code><em>condition</em> ? <em>expr1</em> : <em>expr2</em></code>
 <br> If _condition_ is true, evaluates _expr1_ (and returns its value);
@@ -5098,7 +5101,7 @@ assert(colors[2] == Color.blue);
 You can use enums in [switch statements](#switch-and-case), and
 you'll get a warning if you don't handle all of the enum's values:
 
-你可以在 [Switch 语句](#switch-和-case)中使用枚举，
+你可以在 [Switch 语句](#switch-and-case)中使用枚举，
 但是需要注意的是必须处理枚举值的每一种情况，
 即每一个枚举值都必须成为一个 case 子句，不然会出现警告：
 

--- a/src/_guides/libraries/create-library-packages.md
+++ b/src/_guides/libraries/create-library-packages.md
@@ -384,11 +384,11 @@ of the pubspec allows a user to run it directly without calling
 [`dart pub global run`](/tools/pub/cmd/pub-global#running-a-script-using-dart-pub-global-run).
 
 如果要创建一个公用的命令行工具，应该将这些工具放到公共目录 `bin` 中。
-使用 [`pub global activate`](/tools/pub/cmd/pub-global#activating-a-package) 命令行
+使用 [`dart pub global activate`](/tools/pub/cmd/pub-global#activating-a-package) 命令行
 来运行工具。
 在 pubspec 的 [`executables` 部分](/tools/pub/pubspec#executables)
 列出的工具允许用户直接运行它而无需调用
-[`pub global run`](/tools/pub/cmd/pub-global#running-a-script-using-pub-global-run)。
+[`dart pub global run`](/tools/pub/cmd/pub-global#running-a-script-using-dart-pub-global-run)。
 
 It's helpful if you include an example of how to use your library.
 This goes into the `example` directory at the top of the package.

--- a/src/null-safety/index.md
+++ b/src/null-safety/index.md
@@ -88,6 +88,7 @@ final b = Foo();
 To indicate that a variable might have the value `null`,
 just add `?` to its type declaration:
 
+<a id="creating-variables"></a>
 若你想让变量可以为 `null`，只需要在类型声明后加上 `?`。
 
 ```dart
@@ -157,6 +158,7 @@ To enable sound null safety, set the
 to a [language version][] of 2.12 or later.
 For example, your `pubspec.yaml` file might have the following constraints:
 
+<a id="constraints"></a>
 想要启用健全空安全，你需要将 [SDK 的最低版本约束](/tools/pub/pubspec#sdk-constraints)
 设定为 2.12 或者更高的 [语言版本][language version]。
 例如，你的 `pubspec.yaml` 可以设置为如下的限制：

--- a/src/null-safety/migration-guide.md
+++ b/src/null-safety/migration-guide.md
@@ -676,7 +676,7 @@ soon as you migrate:
 
 * [Set the package version to indicate a breaking change.](#package-version)
 
-  [调整 package 的版本，表示该版本包含了破坏性的改动。](#version)
+  [调整 package 的版本，表示该版本包含了破坏性的改动。](#package-version)
 
 * [Update the SDK constraints and package dependencies.](#check-your-pubspec)
 

--- a/src/null-safety/unsound-null-safety.md
+++ b/src/null-safety/unsound-null-safety.md
@@ -111,7 +111,7 @@ they can only run with unsound null safety.
 健全的空安全唾手可得。
 当你的程序入口的库已经迁移至空安全，Dart 会自动以健全的空安全运行你的代码。
 如果你导入了非空安全的库，会有一条提示告诉你，你的程序只能
-[以非健全的空安全运行](#analyzing-and-testing)。
+以非健全的空安全运行。
 
 ## Migrating incrementally
 


### PR DESCRIPTION
继续 [上个 PR](https://github.com/cfug/dart.cn/pull/392) 提到内容的修复，原本以为把 error 改掉就好，后来观察发现 `link-check` 比想象中的严格，[24 条 warnings](https://github.com/cfug/dart.cn/actions/runs/3358535050/jobs/5567664767#step:8:70) 中提到的 `HTTP 200 but missing anchor` 也要修复。

这个 PR 已经修复了这些链接锚记的缺失问题。

猜测有一部分可能是因为翻译工具将双语显示关闭（只保留中文）之后，将英文句段上面的 `<a>` 标签同时移除了的原因。