### PR TITLE
[内容修订] src/_guides/language/language-tour.md

### DIFF
--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -1888,7 +1888,7 @@ Although it often makes sense to place positional arguments first,
 named arguments can be placed anywhere in the argument list
 when it suits your API:
 
-尽管先使用位置参数会比较合理，但你也可以在任意位置使用命名参数，
+尽管将位置参数放在最前面通常比较合理，但你也可以将命名参数放在参数列表的任意位置，
 让整个调用的方式看起来更适合你的 API：
 
 <?code-excerpt "misc/lib/language_tour/functions.dart (named-arguments-anywhere)"?>

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -2623,7 +2623,7 @@ runtime.
 | Operator  | Meaning                                   |
 |-----------+-------------------------------------------|
 | `as`      | Typecast (also used to specify [library prefixes](#specifying-a-library-prefix))
-| `as`      | 类型转换（也用作指定 [类前缀](#specifying-a-library-prefix))）
+| `as`      | 类型转换（也用作指定 [库前缀](#specifying-a-library-prefix))）
 | `is`      | True if the object has the specified type
 | `is`      | 如果对象是指定类型则返回 true
 | `is!`     | True if the object doesn't have the specified type
@@ -2701,7 +2701,7 @@ an operation with an assignment.
 
 Here’s how compound assignment operators work:
 
-下表解释了符合运算符的原理：
+下表解释了复合运算符的原理：
 
 |-----------+----------------------+-----------------------|
 |    场景    |       复合运算        |        等效表达式       |

--- a/src/_guides/language/language-tour.md
+++ b/src/_guides/language/language-tour.md
@@ -2326,7 +2326,7 @@ void main() {
 Here's an example of testing top-level functions, static methods, and
 instance methods for equality:
 
-下面是顶级函数，静态方法和示例方法相等性的测试示例：
+下面是顶级函数，静态方法和实例方法相等性的测试示例：
 
 <?code-excerpt "misc/lib/language_tour/function_equality.dart"?>
 ```dart


### PR DESCRIPTION

### 更新内容描述
#### 目的：
减少此处译文的理解成本，使描述更准确（使用参数通常理解在方法体里，此处是调用方法）

#### 原文：
![image](https://user-images.githubusercontent.com/11385150/202075603-4ad38c51-d508-4fb9-abc4-73183e325739.png)
#### 现译文：
![image](https://user-images.githubusercontent.com/11385150/202075691-86713580-aaed-4381-9b72-327afe0a4475.png)

#### 修改后译文：
尽管将位置参数放在最前面通常比较合理，但你也可以将命名参数放在参数列表的任意位置，让整个调用的方式看起来更适合你的 API：