### PR TITLE
[内容修订] src/_guides/language/effective-dart/style.md

### DIFF
--- a/src/_guides/language/effective-dart/style.md
+++ b/src/_guides/language/effective-dart/style.md
@@ -50,7 +50,7 @@ Identifiers come in three flavors in Dart.
     even for acronyms,
     and separate words with `_`.
 
-    `lowercase_with_underscores` 只是用小写字母单词，即使是缩略词，
+    `lowercase_with_underscores` 只使用小写字母单词，即使是缩略词，
     并且单词之间使用 `_` 连接。
 
 


### PR DESCRIPTION
英文 only lowercase letters 翻译为`只使用` 比 `只是用` 更符合原意
