### PR TITLE
[内容修订] src/content/language/variables.md

### DIFF
--- a/src/content/language/variables.md
+++ b/src/content/language/variables.md
@@ -140,7 +140,7 @@ Null safety flags a non-null variable when it has been either:
 
 * Not initialized with a non-null value.
 
-  使用非空值不初始化。
+  未使用非空值进行初始化。
 
 * Assigned a `null` value.
 

--- a/src/content/language/variables.md
+++ b/src/content/language/variables.md
@@ -136,7 +136,7 @@ Sound null safety changes potential **runtime errors**
 into **edit-time** analysis errors.
 Null safety flags a non-null variable when it has been either:
 
-空安全将潜在的 **运行时错误** 转变为 **编辑时** 分析错误。当非空变量处于以下任一状态时，空安全会标记该变量：
+空安全将潜在的 **运行时错误** 转变为 **编辑时** 分析错误。当非空变量处于以下任一状态时，空安全会识别该变量：
 
 * Not initialized with a non-null value.
 

--- a/src/content/language/variables.md
+++ b/src/content/language/variables.md
@@ -136,7 +136,7 @@ Sound null safety changes potential **runtime errors**
 into **edit-time** analysis errors.
 Null safety flags a non-null variable when it has been either:
 
-空安全将潜在的 **运行时错误** 转变为 **编辑时** 分析错误。当非空变量已经是以下情况之一时，空安全标记为非空变量：
+空安全将潜在的 **运行时错误** 转变为 **编辑时** 分析错误。当非空变量处于以下任一状态时，空安全会标记该变量：
 
 * Not initialized with a non-null value.
 


### PR DESCRIPTION
### 解决的 Issues
Fix #453 

### 更新内容描述
英文原文：Null safety flags a non-null variable when it has been either:
原翻译：当非空变量已经是以下情况之一时，空安全标记为非空变量：
改为：当非空变量处于以下任一状态时，空安全会识别该变量：

英文原文：Not initialized with a non-null value.
原翻译：使用非空值不初始化。
改为：未使用非空值进行初始化。