### PR TITLE
Fix: Page GitHub links with '. /'

### DIFF
--- a/src/_includes/page-github-links.html
+++ b/src/_includes/page-github-links.html
@@ -4,7 +4,7 @@ Style the button pair using the `#page-github-links` selector.
 {% endcomment -%}
 
 {% assign repo = repo | default: site.repo.this -%}
-{% capture path -%} {{repo}}/tree/{{site.branch}}/{{page.inputPath}} {%- endcapture -%}
+{% capture path -%} {{repo}}/tree/{{site.branch}}/{{page.inputPath | regex_replace: '^./'}} {%- endcapture -%}
 {% assign siteTitle = title | default: page.url -%}
 {% assign url = site.url | append: page.url -%}
 


### PR DESCRIPTION
![image](https://github.com/cfug/dart.cn/assets/32262985/6494658e-8f0b-4590-95e1-a2aef1e4d842)

```diff
- https://github.com/cfug/dart.cn/tree/main/./src/xx/xx.md
+ https://github.com/cfug/dart.cn/tree/main/src/xx/xx.md
```