### PR TITLE
Fix: Chinese text in anchors was deleted

### DIFF
--- a/src/_11ty/utils/slugify.js
+++ b/src/_11ty/utils/slugify.js
@@ -14,7 +14,9 @@ export function slugify(text) {
     .toLowerCase()
     .trim()
     .replace(/[:.]/g, '-')
-    .replace(/[^a-z0-9\s:._-]/g, '')
+    // .replace(/[^a-z0-9\s:._-]/g, '')
+    // dart.cn - Avoid Chinese text removal
+    .replace(/[^\u4e00-\u9fa5a-z0-9\s:._-]/g, '')
     .replace(/[\s-]+/g, '-')
     .replace(/^-+|-+$/g, '');
 }

--- a/src/content/effective-dart/style.md
+++ b/src/content/effective-dart/style.md
@@ -132,7 +132,7 @@ extension SmartIterable<T> on Iterable<T> { ... }
 <a id="do-name-libraries-and-source-files-using-lowercase_with_underscores"></a>
 ### DO name packages, directories, and source files using `lowercase_with_underscores` {:#do-name-packages-and-file-system-entities-using-lowercase-with-underscores}
 
-### **要** 在`库`，`package`，`文件夹`，`源文件` 中使用 `lowercase_with_underscores` 方式命名 {:#要在库，package，文件夹，源文件中使用 lowercase_with_underscores 方式命名}
+### **要** 在`库`，`package`，`文件夹`，`源文件` 中使用 `lowercase_with_underscores` 方式命名
 
 {% include 'linter-rule-mention.md', rules:'file_names, package_names' %}
 

--- a/src/content/guides/libraries/create-packages.md
+++ b/src/content/guides/libraries/create-packages.md
@@ -430,7 +430,7 @@ For the how-and-why of documenting libraries, see
 
 ## Distributing an open source library {:#distributing-a-library}
 
-## 分发开源 Library {:#分发开源 Library}
+## 分发开源 Library
 
 If your library is open source,
 we recommend sharing it on the [pub.dev site.]({{site.pub}})

--- a/src/content/null-safety/faq.md
+++ b/src/content/null-safety/faq.md
@@ -496,7 +496,7 @@ The fix is to explicitly create such lists as `List<dynamic>`.
 
 ## Why does the migration tool add comments to my code? {:#migration-comments}
 
-## 为什么迁移工具在我的代码中添加了注释 {:#为什么迁移工具在我的代码中添加了注释}
+## 为什么迁移工具在我的代码中添加了注释
 
 The migration tool adds `/* == false */` or `/* == true */` comments when it
 sees conditions that will always be false or true while running in sound mode.

--- a/src/content/null-safety/index.md
+++ b/src/content/null-safety/index.md
@@ -186,7 +186,7 @@ listed by the analyzer.
 
 ## Dart 2.x and null safety {:#enable-null-safety}
 
-## 启用和禁用空安全 {:#启用和禁用空安全}
+## 启用和禁用空安全
 
 From Dart 2.12 to 2.19, you need to enable null safety.
 You cannot use null safety in SDK versions earlier than Dart 2.12.
@@ -214,7 +214,7 @@ environment:
 
 ## Migrating existing code {:#migrate}
 
-## 迁移现有的 package 或应用 {:#迁移现有的 package 或应用}
+## 迁移现有的 package 或应用
 
 :::warning
 

--- a/src/content/null-safety/migration-guide.md
+++ b/src/content/null-safety/migration-guide.md
@@ -91,7 +91,7 @@ watch this video:
 
 ## 1. Wait to migrate {:#step1-wait}
 
-## 1. 等待迁移 {:#step1-等待迁移}
+## 1. 等待迁移
 
 We strongly recommend migrating code in order, 
 with the leaves of the dependency graph being migrated first.
@@ -245,7 +245,7 @@ update its dependencies to null-safe versions:
 
 ## 2. Migrate {:#step2-migrate}
 
-## 2. 迁移 {:#step2-迁移}
+## 2. 迁移
 
 Most of the changes that your code needs to be null safe
 are easily predictable.
@@ -291,7 +291,7 @@ For additional help while migrating code, check the
 
 ### Using the migration tool {:#migration-tool}
 
-### 使用迁移工具 {:#使用迁移工具}
+### 使用迁移工具
 
 The migration tool takes a package of null-unsafe Dart code
 and converts it to null safety.
@@ -403,7 +403,7 @@ you can improve the migration result.
 
 #### Improving migration results {:#hint-markers}
 
-#### 改进迁移的结果 {:#改进迁移的结果}
+#### 改进迁移的结果
 
 When analysis infers the wrong nullability,
 you can override its proposed edits by inserting temporary hint markers:
@@ -658,7 +658,7 @@ for more help on migrating code by hand.
 
 ## 3. Analyze {:#step3-analyze}
 
-## 3. 分析 {:#step3-分析}
+## 3. 分析
 
 Update your packages
 (using `dart pub get` in your IDE or on the command line).
@@ -678,7 +678,7 @@ $ dart analyze     # or `flutter analyze`
 
 ## 4. Test {:#step4-test}
 
-## 4. 测试 {:#step4-测试}
+## 4. 测试
 
 If your code passes analysis, run tests:
 
@@ -701,7 +701,7 @@ If so, revert your code changes before using the migration tool again.
 
 ## 5. Publish {:#step5-publish}
 
-## 5. 发布 {:#step5-发布}
+## 5. 发布
 
 We encourage you to publish packages—possibly as prereleases—as 
 soon as you migrate:
@@ -728,7 +728,7 @@ soon as you migrate:
 
 ### Update the package version {:#package-version}
 
-### 更新 package 的版本 {:#更新 package 的版本}
+### 更新 package 的版本
 
 Update the version of the package
 to indicate a breaking change:

--- a/src/content/overview.md
+++ b/src/content/overview.md
@@ -44,7 +44,7 @@ Dart 作为 Flutter 应用程序的编程语言，为驱动应用运行提供了
 
 ## Dart: The language {:#language}
 
-## Dart 语言 {:#Dart-1}
+## Dart 语言
 
 The Dart language is type safe;
 it uses static type checking to ensure that
@@ -156,7 +156,7 @@ target="_blank" rel="noopener">在此示例自己的窗口中打开它</a>。
 
 ## Dart: The libraries {:#libraries}
 
-## Dart 库 {:#Dart-2}
+## Dart 库
 
 Dart has [a rich set of core libraries](/libraries),
 providing essentials for many everyday programming tasks:
@@ -291,7 +291,7 @@ To find additional APIs, see the
 
 ## Dart: The platforms {:#platform}
 
-## Dart 平台 {:#Dart-3}
+## Dart 平台
 
 Dart's compiler technology lets you run code in different ways:
 
@@ -327,7 +327,7 @@ on iOS, Android, macOS, Windows, Linux, and the web.
 
 #### Dart Native (machine code JIT and AOT) {:#native-platform}
 
-#### 原生平台的 Dart (JIT 和 AOT 机器码) {:#Dart-4}
+#### 原生平台的 Dart (JIT 和 AOT 机器码)
 
 During development, a fast developer cycle is critical for iteration.
 The Dart VM offers a just-in-time compiler (JIT) with
@@ -380,7 +380,7 @@ More information:
 
 #### Dart Web (JavaScript dev & prod) {:#web-platform}
 
-#### Web 平台的 Dart (使用 JavaScript 开发和部署) {:#Dart-5}
+#### Web 平台的 Dart (使用 JavaScript 开发和部署)
 
 Dart Web enables running Dart code on web platforms powered by
 JavaScript. With Dart Web, you compile Dart code to JavaScript code, which in
@@ -425,7 +425,7 @@ More information:
 
 #### The Dart runtime {:#runtime}
 
-#### Dart 运行时环境 {:#Dart-6}
+#### Dart 运行时环境
 
 Regardless of which platform you use or how you compile your code,
 executing the code requires a Dart runtime.
@@ -473,7 +473,7 @@ the [`dart run`](/tools/dart-run) command.
 
 ## Learning Dart {:#learning-dart}
 
-## 学习 Dart {:#学习 Dart}
+## 学习 Dart
 
 You have many choices for learning Dart. Here are a few that we recommend:
 

--- a/src/content/tools/analysis.md
+++ b/src/content/tools/analysis.md
@@ -216,7 +216,7 @@ and `my_other_other_package`, and file #2 to analyze the code in
 
 ## Enabling stricter type checks {:#enabling-additional-type-checks}
 
-## 启用更严格的类型检查 {:#启用更严格的类型检查}
+## 启用更严格的类型检查
 
 If you want stricter static checks than
 the [Dart type system][type-system] requires,
@@ -360,7 +360,7 @@ warning - The generic type 'List<dynamic>' should have explicit type arguments b
 
 ## Enabling and disabling linter rules {:#enabling-linter-rules}
 
-## 启用和停用 linter 规则 {:#启用和停用 linter 规则}
+## 启用和停用 linter 规则
 
 The analyzer package also provides a code linter. A wide variety of
 [linter rules][] are available. Linters tend to be
@@ -376,7 +376,7 @@ analyzer 包同样提供一个代码 linter，并包含一份广泛多样的 [li
 
 ### Enabling Dart team recommended linter rules {:#lints}
 
-### 启用 Dart 团队推荐的 linter 规则 {:#启用 Dart 团队推荐的 linter 规则}
+### 启用 Dart 团队推荐的 linter 规则
 
 The Dart team provides two sets of recommended linter rules
 in the [lints package][]:
@@ -466,7 +466,7 @@ or [disable individual rules][].
 
 ### Enabling individual rules {:#individual-rules}
 
-### 启用单条规则 {:#启用单条规则}
+### 启用单条规则
 
 To enable a single linter rule, add `linter:` to the analysis options file
 as a top-level key,

--- a/src/content/tools/dartpad/index.md
+++ b/src/content/tools/dartpad/index.md
@@ -79,7 +79,7 @@ try running some samples and creating a simple command-line app.
 
 ### Open DartPad and run a sample {:#step-1-open-and-run}
 
-### 打开 DartPad 并运行一些示例 {:#打开 DartPad 并运行一些示例}
+### 打开 DartPad 并运行一些示例
 
 1. Go to [DartPad][]{:target="_blank" rel="noopener"}.
 
@@ -104,7 +104,7 @@ try running some samples and creating a simple command-line app.
 
 ### Create a command-line app {:#step-2-server}
 
-### 创建一个命令行应用 {:#创建一个命令行应用}
+### 创建一个命令行应用
 
 To create a simple command-line app,
 start by creating a new snippet:
@@ -180,7 +180,7 @@ DartPad 支持的语言功能和 API 取决于 DartPad 使用的 **Dart SDK** �
 
 ## Embedding DartPad in web pages {:#embedding}
 
-## 网页中嵌入 DartPad {:#网页中嵌入 DartPad}
+## 网页中嵌入 DartPad
 
 You can embed DartPad inside of web pages,
 customizing it to suit your use case.

--- a/src/content/tools/index.md
+++ b/src/content/tools/index.md
@@ -123,7 +123,7 @@ A [Language Server Protocol implementation][LSP] is also available for
 
 ### Command-line tools {:#cli}
 
-### 命令行工具 {:#命令行工具}
+### 命令行工具
 
 The Dart SDK includes the following general-purpose `dart` tool:
 
@@ -151,7 +151,7 @@ Dart SDK 中包含下面的 `dart` 工具：
 
 ## Tool for developing web apps {:#web}
 
-## 开发 Web 应用的工具 {:#开发 Web 应用的工具}
+## 开发 Web 应用的工具
 
 The following tool supports developing web apps:
 
@@ -165,7 +165,7 @@ The following tool supports developing web apps:
 
 ## Tools for developing command-line apps and servers {:#server}
 
-## 开发命令行应用和服务器的工具 {:#开发命令行应用和服务器的工具}
+## 开发命令行应用和服务器的工具
 
 The following tools support developing or running
 command-line apps and servers:

--- a/src/content/tools/pub/publishing.md
+++ b/src/content/tools/pub/publishing.md
@@ -160,7 +160,7 @@ Pub 在 `pub.dev/packages/<your_package>` 里，
 
 ### Advantages of using a verified publisher {:#verified-publisher}
 
-### 使用已验证发布者的优点 {:#使用已验证发布者的优点}
+### 使用已验证发布者的优点
 
 You can publish packages using either a verified publisher (recommended)
 or an independent Google Account.
@@ -189,7 +189,7 @@ Using a verified publisher has the following advantages:
 
 ### Creating a verified publisher {:#create-verified-publisher}
 
-### 创建一个已验证发布者 {:#创建一个已验证发布者}
+### 创建一个已验证发布者
 
 To create a verified publisher, follow these steps:
 
@@ -645,7 +645,7 @@ then you can ignore the following warning from `dart pub publish`:
 
 ## Retracting a package version {:#retract}
 
-## 撤回 package 的某个版本 {:#撤回 package 的某个版本}
+## 撤回 package 的某个版本
 
 To prevent new package consumers from adopting a recently
 published version of your package, you can retract that package version
@@ -784,7 +784,7 @@ pub.dev，该账号需要是该 package 的上传者或
 
 ## Marking packages as discontinued {:#discontinue}
 
-## 把 package 标记为终止 {:#把 package 标记为终止}
+## 把 package 标记为终止
 
 Although packages always remain published, it can be useful to signal to
 developers that a package is no longer being actively maintained.

--- a/src/content/tutorials/language/streams.md
+++ b/src/content/tutorials/language/streams.md
@@ -245,7 +245,7 @@ Future<int> lastPositive(Stream<int> stream) =>
 
 ## Two kinds of streams {:#two-kinds-of-streams}
 
-## Stream 的两种类型 {:#Stream 的两种类型}
+## Stream 的两种类型
 
 There are two kinds of streams.
 
@@ -253,7 +253,7 @@ Stream 有两种类型。
 
 ### Single subscription streams {:#single-subscription-streams}
 
-### Single-Subscription 类型的 Stream {:#Single-Subscription 类型的 Stream}
+### Single-Subscription 类型的 Stream
 
 The most common kind of stream contains a sequence of events that
 are parts of a larger whole.
@@ -278,7 +278,7 @@ the data will be fetched and provided in chunks.
 
 ### Broadcast streams {:#broadcast-streams}
 
-### Broadcast 类型的 Stream {:#Broadcast 类型的 Stream}
+### Broadcast 类型的 Stream
 
 The other kind of stream is intended for individual messages that
 can be handled one at a time. This kind of stream can be used for
@@ -300,7 +300,7 @@ subscription.
 
 ## Methods that process a stream {:#process-stream-methods}
 
-## 处理 Stream 的方法 {:#处理 Stream 的方法}
+## 处理 Stream 的方法
 
 The following methods on [Stream\<T>][Stream] process the stream and return a
 result:
@@ -374,7 +374,7 @@ but mainly for historical reasons.)
 
 ## Methods that modify a stream {:#modify-stream-methods}
 
-## 修改 Stream 的方法 {:#修改 Stream 的方法}
+## 修改 Stream 的方法
 
 The following methods on Stream return a new stream based
 on the original stream.
@@ -461,7 +461,7 @@ Stream<S> mapLogErrors<S, T>(
 
 ### The transform() function {:#transform-function}
 
-### transform() 方法 {:#transform() 方法}
+### transform() 方法
 
 The `transform()` function is not just for error handling;
 it is a more generalized "map" for streams.
@@ -483,7 +483,7 @@ easily implemented by an `async` function.
 
 ### Reading and decoding a file {:#reading-decoding-file}
 
-### 读取和解码文件 {:#读取和解码文件}
+### 读取和解码文件
 
 The following code reads a file and runs two transforms over the stream.
 It first converts the data from UTF8 and then runs it through
@@ -513,7 +513,7 @@ void main(List<String> args) async {
 
 ## The listen() method {:#listen-method}
 
-## listen() 方法 {:#listen() 方法}
+## listen() 方法
 
 The final method on Stream is `listen()`. This is a "low-level"
 method—all other stream functions are defined in terms of `listen()`.

--- a/tool/dart_site/lib/src/commands/generate_effective_dart_toc.dart
+++ b/tool/dart_site/lib/src/commands/generate_effective_dart_toc.dart
@@ -206,7 +206,9 @@ String _generateAnchorHash(String text) => text
     .toLowerCase()
     .trim()
     .replaceAll(RegExp(r'[:.]'), '-')
-    .replaceAll(RegExp(r'[^a-z0-9\s_-]'), '')
+    // .replaceAll(RegExp(r'[^a-z0-9\s_-]'), '')
+    // dart.cn - Avoid Chinese text removal
+    .replaceAll(RegExp(r'[^\u4e00-\u9fa5a-z0-9\s_-]'), '')
     .replaceAll(RegExp(r'[\s-]+'), '-')
     .replaceAll(RegExp(r'^-+|-+$'), '');
 


### PR DESCRIPTION
解决分级标题的锚点会在构建时排除掉中文的问题。
> 锚点内的中文被排除后，大概率会在构建时报错，  
> 之前的解决方案是：为中文分级标题部分指定一个当前文档唯一的锚点。  

解决前：
```html
<h2 id="learning-dart">Learning Dart</h2>
<a class="heading-link" href="#learning-dart" aria-label="Link to 'Learning Dart' section">#</a></div>
<div class="header-wrapper">
<h2 id="dart">学习 Dart</h2>
<a class="heading-link" href="#dart" aria-label="Link to '学习 Dart' section">#</a></div>
```

解决后：
```html
<h2 id="learning-dart">Learning Dart</h2>
<a class="heading-link" href="#learning-dart" aria-label="Link to 'Learning Dart' section">#</a></div>
<div class="header-wrapper">
<h2 id="学习-dart">学习 Dart</h2>
<a class="heading-link" href="#学习-dart" aria-label="Link to '学习 Dart' section">#</a></div>
```